### PR TITLE
support createClass-style getDefaultProps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-decorate",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Build composable, stateful decorators for React.",
   "main": "index.js",
   "bugs": {

--- a/src/__tests__/fields-test.js
+++ b/src/__tests__/fields-test.js
@@ -21,12 +21,23 @@ describe('fields', () => {
     );
   });
 
-  it('toDefaultProps', () => {
-    const Base = {defaultProps: {one: 1}};
-    const first = {defaultProps: stub().returnsArg(0)};
-    const second = {defaultProps: types => ({...types, two: 2})};
-    expect(toDefaultProps([first, second], Base)).to.deep.equal({one: 1, two: 2});
-    expect(first.defaultProps.calledWith(Base.defaultProps)).to.equal(true);
+  describe('toDefaultProps', () => {
+    it('retrieves static defaultProps', () => {
+      const Base = {defaultProps: {one: 1}};
+      const first = {defaultProps: stub().returnsArg(0)};
+      const second = {defaultProps: types => ({...types, two: 2})};
+      expect(toDefaultProps([first, second], Base)).to.deep.equal({one: 1, two: 2});
+      expect(first.defaultProps.calledWith(Base.defaultProps)).to.equal(true);
+    });
+
+    it('retrieves createClass-style getDefaultProps', () => {
+      const mockDefaults = {one: 1};
+      const Base = {getDefaultProps: () => mockDefaults};
+      const first = {defaultProps: stub().returnsArg(0)};
+      const second = {defaultProps: types => ({...types, two: 2})};
+      expect(toDefaultProps([first, second], Base)).to.deep.equal({one: 1, two: 2});
+      expect(first.defaultProps.calledWith(mockDefaults)).to.equal(true);
+    });
   });
 
   it('toPropTypes', () => {

--- a/src/fields.js
+++ b/src/fields.js
@@ -38,7 +38,27 @@ function applyMeta(fieldName, decorators, BaseComponent) {
   );
 }
 
-export const toDefaultProps = applyMeta.bind(null, 'defaultProps');
+function getOriginalDefaults({defaultProps, getDefaultProps}) {
+  if (defaultProps && typeof defaultProps === 'object') {
+    return defaultProps;
+  }
+  if (typeof getDefaultProps === 'function') {
+    return getDefaultProps();
+  }
+  return {};
+}
+
+export function toDefaultProps(decorators, BaseComponent) {
+  return decorators.reduce(
+    (prev, {defaultProps}) => {
+      if (typeof defaultProps === 'function') {
+        return defaultProps(prev);
+      }
+      return prev;
+    },
+    getOriginalDefaults(BaseComponent)
+  );
+}
 
 export const toPropTypes = applyMeta.bind(null, 'propTypes');
 


### PR DESCRIPTION
So decorators work with `React.createClass`.
