### PR TITLE
add contextTypes field and pass context types to handlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-decorate",
-  "version": "5.0.4",
+  "version": "5.1.0",
   "description": "Build composable, stateful decorators for React.",
   "main": "lib/index.js",
   "bugs": {

--- a/src/examples/__tests__/exposeContext-test.js
+++ b/src/examples/__tests__/exposeContext-test.js
@@ -1,0 +1,48 @@
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import exposeContext from '../exposeContext';
+import React, { PropTypes } from 'react';
+
+const MOCK_CONTEXT_FIELD = 'testing';
+const MOCK_CONTEXT_VALUE = 'value';
+
+function MockComponent() {
+  return <div />;
+}
+
+MockComponent.displayName = 'MockComponent';
+
+const DecoratedComponent = exposeContext(
+  MOCK_CONTEXT_FIELD
+)(
+  MockComponent
+);
+
+describe('EXAMPLE: exposeContext', () => {
+  it('generates a proper displayName', () => {
+    expect(
+      DecoratedComponent.displayName
+    ).to.equal(
+      'Decorated(exposeContext(testing))(MockComponent)'
+    );
+  });
+
+  it('generates the correct context types', () => {
+    expect(
+      DecoratedComponent.contextTypes
+    ).to.deep.equal({
+      [MOCK_CONTEXT_FIELD]: PropTypes.any,
+    });
+  });
+
+  it('passes the context field as a prop', () => {
+    const root = shallow(<DecoratedComponent />, {
+      context: {[MOCK_CONTEXT_FIELD]: MOCK_CONTEXT_VALUE}
+    });
+    expect(
+      root.prop(MOCK_CONTEXT_FIELD)
+    ).to.equal(
+      MOCK_CONTEXT_VALUE
+    );
+  });
+});

--- a/src/examples/__tests__/exposeContext-test.js
+++ b/src/examples/__tests__/exposeContext-test.js
@@ -37,7 +37,9 @@ describe('EXAMPLE: exposeContext', () => {
 
   it('passes the context field as a prop', () => {
     const root = shallow(<DecoratedComponent />, {
-      context: {[MOCK_CONTEXT_FIELD]: MOCK_CONTEXT_VALUE}
+      context: {
+        [MOCK_CONTEXT_FIELD]: MOCK_CONTEXT_VALUE,
+      },
     });
     expect(
       root.prop(MOCK_CONTEXT_FIELD)

--- a/src/examples/exposeContext.js
+++ b/src/examples/exposeContext.js
@@ -1,0 +1,26 @@
+import makeDecorator from '../makeDecorator';
+import { PropTypes } from 'react';
+
+export const exposeContext = (contextField) => {
+  return {
+    displayName() {
+      return `exposeContext(${contextField})`;
+    },
+
+    contextTypes(types) {
+      return {
+        ...types,
+        [contextField]: PropTypes.any,
+      };
+    },
+
+    nextProps(props, state, setState, context) {
+      return {
+        ...props,
+        [contextField]: context[contextField],
+      };
+    },
+  };
+};
+
+export default makeDecorator(exposeContext);

--- a/src/fields.js
+++ b/src/fields.js
@@ -3,13 +3,13 @@ export function toDisplayName(decorators, BaseComponent) {
   return `Decorated(${names.join(' -> ')})(${BaseComponent.displayName})`;
 }
 
-export function toInitialState(decorators, props, setState) {
+export function toInitialState(decorators, props, setState, context) {
   const result = decorators.reduce((state, {initialState}, index) => {
     if (typeof initialState === 'function') {
       state[index] = initialState(
         props,
-        setState,
-        setState.bind(null, index)
+        setState.bind(null, index),
+        context
       );
     }
     return state;
@@ -17,12 +17,13 @@ export function toInitialState(decorators, props, setState) {
   return result;
 }
 
-export function toProps(decorators, props, state, setState) {
+export function toProps(decorators, props, state, setState, context) {
   return decorators.reduce(
     (coll, {nextProps}, index) => nextProps(
       coll,
       state[index],
-      setState.bind(null, index)
+      setState.bind(null, index),
+      context
     ),
     props
   );
@@ -32,9 +33,9 @@ function applyMeta(fieldName, decorators, BaseComponent) {
   return decorators.reduce(
     (result, decorator) => {
       const meta = decorator[fieldName];
-      return meta ? meta(result) : result;
+      return meta ? meta(result || {}) : result;
     },
-    BaseComponent[fieldName] || {}
+    BaseComponent[fieldName]
   );
 }
 
@@ -60,12 +61,14 @@ export function toDefaultProps(decorators, BaseComponent) {
   );
 }
 
+export const toContextTypes = applyMeta.bind(null, 'contextTypes');
+
 export const toPropTypes = applyMeta.bind(null, 'propTypes');
 
-export function toUnmount(decorators, props, state) {
+export function toUnmount(decorators, props, state, context) {
   decorators.forEach(({unmount}, index) => {
     if (typeof unmount === 'function') {
-      unmount(props, state[index]);
+      unmount(props, state[index], context);
     }
   });
 }

--- a/src/makeDecoratedComponent.js
+++ b/src/makeDecoratedComponent.js
@@ -1,4 +1,5 @@
 import {
+  toContextTypes,
   toDisplayName,
   toDefaultProps,
   toInitialState,
@@ -16,12 +17,13 @@ export default function makeDecoratedComponent(decorators, BaseComponent) {
       this.state = toInitialState(
         decorators,
         props,
-        this.handleSetState
+        this.handleSetState,
+        this.context
       );
     }
 
     componentWillUnmount() {
-      toUnmount(decorators, this.props, this.state);
+      toUnmount(decorators, this.props, this.state, this.context);
     }
 
     handleSetState(fieldName, value) {
@@ -35,12 +37,18 @@ export default function makeDecoratedComponent(decorators, BaseComponent) {
             decorators,
             this.props,
             this.state,
-            this.handleSetState
+            this.handleSetState,
+            this.context
           )}
         />
       );
     }
   }
+
+  DecoratedComponent.contextTypes = toContextTypes(
+    decorators,
+    BaseComponent
+  );
 
   DecoratedComponent.displayName = toDisplayName(
     decorators,


### PR DESCRIPTION
Allows for defining a `contextTypes` field. Passes `this.context` to various other handlers.
